### PR TITLE
Add GitHub Actions Workflow for Multi-Platform Build and Release of Novelist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,256 @@
+name: Build and Release Novelist
+
+on:
+  workflow_dispatch: # Allows manual triggering
+  push:
+    tags:
+      - 'v*.*.*' # Triggers on version tags like v1.0.0, v1.2.3-alpha
+
+jobs:
+  build_android:
+    name: Build Android
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.19.6'
+          channel: 'stable'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build Android APK
+        run: flutter build apk --release
+
+      - name: Build Android App Bundle (AAB)
+        run: flutter build appbundle --release
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: novelist-android-apk
+          path: build/app/outputs/flutter-apk/app-release.apk
+          if-no-files-found: error # Ensure the artifact exists
+
+      - name: Upload App Bundle (AAB)
+        uses: actions/upload-artifact@v4
+        with:
+          name: novelist-android-aab
+          path: build/app/outputs/bundle/release/app-release.aab
+          if-no-files-found: error # Ensure the artifact exists
+
+  build_ios:
+    name: Build iOS
+    runs-on: macos-latest # iOS builds require macOS
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.19.6'
+          channel: 'stable'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build iOS App
+        run: flutter build ios --release --no-codesign
+
+      - name: Archive iOS App Bundle
+        run: |
+          cd build/ios/iphoneos/
+          zip -r ../../../novelist-ios-app.zip Runner.app
+          cd ../../../
+        # Creates novelist-ios-app.zip in the root of the checkout directory
+
+      - name: Upload iOS App Bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: novelist-ios-app
+          path: novelist-ios-app.zip # Path to the generated zip file
+          if-no-files-found: error
+
+  build_linux:
+    name: Build Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.19.6'
+          channel: 'stable'
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
+
+      - name: Install project dependencies
+        run: flutter pub get
+
+      - name: Build Linux application
+        run: flutter build linux --release
+
+      - name: Archive Linux release bundle
+        run: |
+          cd build/linux/x64/release/bundle/
+          zip -r ../../../../../novelist-linux.zip .
+          cd ../../../../../
+        # Creates novelist-linux.zip in the root of the checkout directory containing the bundle contents
+
+      - name: Upload Linux release bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: novelist-linux
+          path: novelist-linux.zip # Path to the generated zip file
+          if-no-files-found: error
+
+  build_macos:
+    name: Build macOS
+    runs-on: macos-latest # macOS builds require macOS runner
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.19.6'
+          channel: 'stable'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build macOS application
+        run: flutter build macos --release
+
+      - name: Archive macOS application bundle
+        run: |
+          cd build/macos/Build/Products/Release/
+          zip -r ../../../../novelist-macos.zip novelist.app
+          cd ../../../../
+        # Creates novelist-macos.zip in the root of the checkout directory
+
+      - name: Upload macOS application bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: novelist-macos
+          path: novelist-macos.zip # Path to the generated zip file
+          if-no-files-found: error
+
+  build_windows:
+    name: Build Windows
+    runs-on: windows-latest # Windows builds require Windows runner
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.19.6'
+          channel: 'stable'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build Windows application
+        run: flutter build windows --release
+
+      - name: Archive Windows release
+        shell: pwsh # Using PowerShell for Compress-Archive
+        run: |
+          Compress-Archive -Path build/windows/runner/Release/* -DestinationPath novelist-windows.zip
+        # Creates novelist-windows.zip in the root of the checkout directory
+
+      - name: Upload Windows release
+        uses: actions/upload-artifact@v4
+        with:
+          name: novelist-windows
+          path: novelist-windows.zip # Path to the generated zip file
+          if-no-files-found: error
+
+  build_web:
+    name: Build Web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.19.6'
+          channel: 'stable'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build Web application
+        run: flutter build web --release
+
+      - name: Archive Web release
+        run: |
+          cd build/web/
+          zip -r ../../novelist-web.zip .
+          cd ../../
+        # Creates novelist-web.zip in the root of the checkout directory
+
+      - name: Upload Web release
+        uses: actions/upload-artifact@v4
+        with:
+          name: novelist-web
+          path: novelist-web.zip # Path to the generated zip file
+          if-no-files-found: error
+
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: [build_android, build_ios, build_linux, build_macos, build_windows, build_web] # Depends on all build jobs
+    permissions:
+      contents: write # Required to create a release
+    steps:
+      - name: Checkout repository # Optional, but good for context and if release notes refer to commits
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./release-artifacts/ # Download all artifacts into this directory
+          # No specific 'name' means it downloads all artifacts from the run
+
+      - name: Display structure of downloaded artifacts # For debugging/verification
+        run: ls -R ./release-artifacts/
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "./release-artifacts/*/*" # Path to all artifacts within their respective subdirectories
+          # Example: ./release-artifacts/novelist-android-apk/app-release.apk
+          # The ncipollo action will search recursively in subdirectories if a wildcard like * is used at the end of a path segment.
+          # However, to be more explicit and ensure all files are caught if structures vary slightly:
+          # artifacts: |
+          #   ./release-artifacts/novelist-android-apk/app-release.apk
+          #   ./release-artifacts/novelist-android-aab/app-release.aab
+          #   ./release-artifacts/novelist-ios-app/novelist-ios-app.zip
+          #   ./release-artifacts/novelist-linux/novelist-linux.zip
+          #   ./release-artifacts/novelist-macos/novelist-macos.zip
+          #   ./release-artifacts/novelist-windows/novelist-windows.zip
+          #   ./release-artifacts/novelist-web/novelist-web.zip
+          # For simplicity, the wildcard should work if download-artifact creates a flat structure or predictable subdirs.
+          # The default download-artifact behavior is to create a directory for each artifact.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }} # Uses the tag that triggered the workflow
+          name: "Release ${{ github.ref_name }}"
+          body: "Automated release for version ${{ github.ref_name }}. See CHANGELOG.md for details or auto-generated notes below."
+          generateReleaseNotes: true # Generates release notes from commits since last release
+          prerelease: ${{ contains(github.ref_name, '-') }} # Mark as pre-release if tag contains a hyphen (e.g., v1.0.0-alpha)


### PR DESCRIPTION
This PR introduces a comprehensive GitHub Actions workflow file, `Build and Release Novelist`, that automates the build and release process for the Novelist app across all major platforms. The workflow is designed to be triggered manually or by pushing version tags (`v*.*.*`), enabling both on-demand and versioned releases.

### Key Features:

* **Platform Coverage**: Builds and packages Novelist for:

  * Android (APK & AAB)
  * iOS (App Bundle zip)
  * Linux (zip)
  * macOS (zip)
  * Windows (zip)
  * Web (zip)

* **Artifact Management**: Each build step uploads its respective release artifact to GitHub Actions for use in the final release.

* **Automated GitHub Release**:

  * Gathers all build artifacts.
  * Automatically creates a GitHub release using the triggering tag.
  * Marks pre-releases if the tag includes a hyphen (e.g., `-alpha`).
  * Auto-generates release notes from commit history.

### Benefits:

* Simplifies multi-platform release workflow.
* Ensures consistent and reproducible builds.
* Centralizes artifact handling and release distribution.

This workflow sets the foundation for continuous delivery across mobile, desktop, and web platforms.
