### PR TITLE
Add Persistent Reader and App Theme Settings with SettingsService

### DIFF
--- a/src/lib/core/app_routes.dart
+++ b/src/lib/core/app_routes.dart
@@ -38,24 +38,3 @@ class AppRoutes {
     );
   }
 }
-
-// To use named routes in main.dart:
-//
-// class NovelistApp extends StatelessWidget {
-//   const NovelistApp({super.key});
-//
-//   @override
-//   Widget build(BuildContext context) {
-//     return MaterialApp(
-//       title: 'Novelist',
-//       theme: ThemeData(
-//         colorScheme: ColorScheme.fromSeed(seedColor: Colors.blueGrey),
-//       ),
-//       initialRoute: AppRoutes.library, // Set initial route
-//       onGenerateRoute: AppRoutes.generateRoute, // Use the route generator
-//     );
-//   }
-// }
-//
-// And to navigate:
-// Navigator.pushNamed(context, AppRoutes.reading, arguments: myBook);

--- a/src/lib/main.dart
+++ b/src/lib/main.dart
@@ -1,49 +1,42 @@
 // lib/main.dart
 import 'package:flutter/material.dart';
-import 'package:novelist/ui/screens/library_screen.dart'; // We'll create this next
-import 'package:hive_flutter/hive_flutter.dart'; // For Hive in Flutter
-import 'package:novelist/models/book.dart'; // Assuming you have a Book model
+import 'package:novelist/ui/screens/library_screen.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:novelist/models/book.dart';
+import 'package:novelist/services/settings_service.dart'; // Import SettingsService
 
 void main() async {
-    // Ensure Flutter bindings are initialized
   WidgetsFlutterBinding.ensureInitialized();
+  await Hive.initFlutter();
+  Hive.registerAdapter(BookAdapter());
+  Hive.registerAdapter(BookFormatAdapter());
 
-  // Initialize Hive for Flutter
-  await Hive.initFlutter(); // Use initFlutter for Flutter apps
+  // Load initial theme mode
+  final settingsService = SettingsService();
+  final initialThemeMode = await settingsService.getAppThemeMode();
 
-  // Register your TypeAdapters (created in Step 3)
-  Hive.registerAdapter(BookAdapter()); // We'll generate BookAdapter next
-  Hive.registerAdapter(BookFormatAdapter()); // For the enum
-
-  // TODO: Register adapters for ReadingProgress, Bookmark, Note, Annotation later
-  // Hive.registerAdapter(ReadingProgressAdapter());
-  // Hive.registerAdapter(BookmarkAdapter());
-
-  // Open your boxes (you can open them here or in the services that use them)
-  // It's often good practice to open them where they are first needed or in a dedicated init service.
-  // For simplicity now, we can open the library box here or ensure it's opened by LibraryService.
-  // await Hive.openBox<Book>(kLibraryBox); // kLibraryBox from app_constants.dart
-
-  runApp(const NovelistApp());
+  runApp(NovelistApp(initialThemeMode: initialThemeMode));
 }
 
 class NovelistApp extends StatelessWidget {
-  const NovelistApp({super.key});
+  final ThemeMode initialThemeMode; // Accept initial theme mode
+
+  const NovelistApp({super.key, required this.initialThemeMode});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Novelist', // App title
+      title: 'Novelist',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blueGrey), // Or your preferred seed color
-        // TODO: Define more theme aspects: typography, other colors for light/dark themes
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blueGrey, brightness: Brightness.light),
+        // Define other light theme properties
       ),
-      // TODO: Implement dark theme later:
-      // darkTheme: ThemeData.dark().copyWith(
-      //   colorScheme: ColorScheme.fromSeed(seedColor: Colors.blueGrey, brightness: Brightness.dark),
-      // ),
-      // themeMode: ThemeMode.system, // Or allow user to choose
-      home: const LibraryScreen(), // Start with the library screen
+      darkTheme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blueGrey, brightness: Brightness.dark),
+        // Define other dark theme properties
+      ),
+      themeMode: initialThemeMode, // Use the loaded theme mode
+      home: const LibraryScreen(),
     );
   }
 }

--- a/src/lib/services/settings_service.dart
+++ b/src/lib/services/settings_service.dart
@@ -1,0 +1,67 @@
+// lib/services/settings_service.dart
+import 'package:flutter/material.dart'; // For ThemeMode
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:novelist/core/app_constants.dart'; // For keys
+
+// Define an enum for our reader themes if not using ThemeMode directly for all
+enum ReaderThemeSetting { light, dark, sepia, system }
+
+class SettingsService {
+  static const String _keyReaderTheme = 'reader_theme';
+  static const String _keyDefaultFontSize = 'default_font_size';
+
+  SharedPreferences? _prefs;
+
+  Future<void> _initPrefs() async {
+    _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  // --- Reader Theme ---
+  Future<void> saveReaderTheme(ReaderThemeSetting theme) async {
+    await _initPrefs();
+    await _prefs!.setString(_keyReaderTheme, theme.name); // Store enum by its name
+  }
+
+  Future<ReaderThemeSetting> getReaderTheme() async {
+    await _initPrefs();
+    final String? themeName = _prefs!.getString(_keyReaderTheme);
+    if (themeName != null) {
+      try {
+        return ReaderThemeSetting.values.byName(themeName);
+      } catch (_) {
+        return ReaderThemeSetting.system; // Default if stored value is invalid
+      }
+    }
+    return ReaderThemeSetting.system; // Default
+  }
+
+  // --- Default Font Size ---
+  Future<void> saveDefaultFontSize(double size) async {
+    await _initPrefs();
+    await _prefs!.setDouble(_keyDefaultFontSize, size);
+  }
+
+  Future<double> getDefaultFontSize() async {
+    await _initPrefs();
+    return _prefs!.getDouble(_keyDefaultFontSize) ?? 16.0; // Default font size
+  }
+
+  // --- App Theme (controls MaterialApp light/dark/system) ---
+  Future<void> saveAppThemeMode(ThemeMode themeMode) async {
+    await _initPrefs();
+    await _prefs!.setString(kThemeModeKey, themeMode.name);
+  }
+
+  Future<ThemeMode> getAppThemeMode() async {
+    await _initPrefs();
+    final String? themeName = _prefs!.getString(kThemeModeKey);
+    if (themeName != null) {
+      try {
+        return ThemeMode.values.byName(themeName);
+      } catch (_) {
+        return ThemeMode.system; 
+      }
+    }
+    return ThemeMode.system;
+  }
+}

--- a/src/lib/services/settings_service.dart
+++ b/src/lib/services/settings_service.dart
@@ -1,14 +1,15 @@
 // lib/services/settings_service.dart
-import 'package:flutter/material.dart'; // For ThemeMode
+import 'package:flutter/material.dart'; 
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:novelist/core/app_constants.dart'; // For keys
+import 'package:novelist/core/app_constants.dart';
+import 'package:novelist/core/error_handler.dart';
 
-// Define an enum for our reader themes if not using ThemeMode directly for all
 enum ReaderThemeSetting { light, dark, sepia, system }
 
 class SettingsService {
-  static const String _keyReaderTheme = 'reader_theme';
-  static const String _keyDefaultFontSize = 'default_font_size';
+  static const String _keyReaderTheme = 'reader_theme_v2'; // Added v2 for new enum
+  static const String _keyDefaultFontSize = 'default_font_size_v2'; // Added v2
+  static const String _keyReaderFontFamily = 'reader_font_family_v2'; // Added v2
 
   SharedPreferences? _prefs;
 
@@ -19,7 +20,7 @@ class SettingsService {
   // --- Reader Theme ---
   Future<void> saveReaderTheme(ReaderThemeSetting theme) async {
     await _initPrefs();
-    await _prefs!.setString(_keyReaderTheme, theme.name); // Store enum by its name
+    await _prefs!.setString(_keyReaderTheme, theme.name); 
   }
 
   Future<ReaderThemeSetting> getReaderTheme() async {
@@ -29,10 +30,11 @@ class SettingsService {
       try {
         return ReaderThemeSetting.values.byName(themeName);
       } catch (_) {
-        return ReaderThemeSetting.system; // Default if stored value is invalid
+        ErrorHandler.logWarning("Invalid stored reader theme: $themeName, defaulting to system.", scope: "SettingsService");
+        return ReaderThemeSetting.system; 
       }
     }
-    return ReaderThemeSetting.system; // Default
+    return ReaderThemeSetting.system; 
   }
 
   // --- Default Font Size ---
@@ -43,9 +45,20 @@ class SettingsService {
 
   Future<double> getDefaultFontSize() async {
     await _initPrefs();
-    return _prefs!.getDouble(_keyDefaultFontSize) ?? 16.0; // Default font size
+    return _prefs!.getDouble(_keyDefaultFontSize) ?? 16.0; 
   }
 
+  // --- Reader Font Family ---
+  Future<void> saveReaderFontFamily(String fontFamily) async {
+    await _initPrefs();
+    await _prefs!.setString(_keyReaderFontFamily, fontFamily);
+  }
+
+  Future<String> getReaderFontFamily() async {
+    await _initPrefs();
+    return _prefs!.getString(_keyReaderFontFamily) ?? 'Default'; 
+  }
+  
   // --- App Theme (controls MaterialApp light/dark/system) ---
   Future<void> saveAppThemeMode(ThemeMode themeMode) async {
     await _initPrefs();
@@ -59,6 +72,7 @@ class SettingsService {
       try {
         return ThemeMode.values.byName(themeName);
       } catch (_) {
+        ErrorHandler.logWarning("Invalid stored app theme: $themeName, defaulting to system.", scope: "SettingsService");
         return ThemeMode.system; 
       }
     }

--- a/src/lib/ui/screens/settings_screen.dart
+++ b/src/lib/ui/screens/settings_screen.dart
@@ -15,9 +15,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
   
   ReaderThemeSetting _currentReaderTheme = ReaderThemeSetting.system;
   double _currentDefaultFontSize = 16.0;
-  ThemeMode _currentAppThemeMode = ThemeMode.system; // For overall app theme
+  String _currentReaderFontFamily = 'Default';
+  ThemeMode _currentAppThemeMode = ThemeMode.system;
 
   bool _isLoading = true;
+
+  final List<String> _fontFamilyOptions = const ['Default', 'Serif', 'Sans-Serif', 'Times New Roman', 'Arial', 'Georgia'];
 
   @override
   void initState() {
@@ -29,6 +32,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     setState(() { _isLoading = true; });
     _currentReaderTheme = await _settingsService.getReaderTheme();
     _currentDefaultFontSize = await _settingsService.getDefaultFontSize();
+    _currentReaderFontFamily = await _settingsService.getReaderFontFamily();
     _currentAppThemeMode = await _settingsService.getAppThemeMode();
     if (mounted) {
       setState(() { _isLoading = false; });
@@ -36,43 +40,53 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<void> _updateReaderTheme(ReaderThemeSetting? newTheme) async {
-    if (newTheme != null) {
+    if (newTheme != null && newTheme != _currentReaderTheme) {
       await _settingsService.saveReaderTheme(newTheme);
       if (mounted) {
-        setState(() {
-          _currentReaderTheme = newTheme;
-        });
-        // Optionally, provide immediate feedback or tell user to restart reader/app for some settings
-      }
-    }
-  }
-
-  Future<void> _updateDefaultFontSize(double newSize) async {
-    await _settingsService.saveDefaultFontSize(newSize);
-    if (mounted) {
-      setState(() {
-        _currentDefaultFontSize = newSize;
-      });
-    }
-  }
-  
-  Future<void> _updateAppThemeMode(ThemeMode? newMode) async {
-    if (newMode != null) {
-      await _settingsService.saveAppThemeMode(newMode);
-      if (mounted) {
-        setState(() {
-          _currentAppThemeMode = newMode;
-        });
-        // This change might require a way to notify MaterialApp to rebuild.
-        // Often done via a ChangeNotifierProvider at the root or by restarting.
-        // For now, saving it is the first step.
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('App theme change will apply on next app start (or with theme controller).')),
+        setState(() { _currentReaderTheme = newTheme; });
+         ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Reader theme saved. Changes apply when reader is opened/reopened.')),
         );
       }
     }
   }
 
+  Future<void> _updateDefaultFontSize(double newSize) async {
+    // This is called on onChangeEnd of slider
+    if (newSize != _currentDefaultFontSize) {
+      await _settingsService.saveDefaultFontSize(newSize);
+      if (mounted) {
+        // No need to call setState for _currentDefaultFontSize here as slider's onChanged does it.
+         ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Default font size saved.')),
+        );
+      }
+    }
+  }
+
+  Future<void> _updateReaderFontFamily(String? newFontFamily) async {
+    if (newFontFamily != null && newFontFamily != _currentReaderFontFamily) {
+      await _settingsService.saveReaderFontFamily(newFontFamily);
+      if (mounted) {
+        setState(() { _currentReaderFontFamily = newFontFamily; });
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Reader font family saved. Changes apply when reader is opened/reopened.')),
+        );
+      }
+    }
+  }
+  
+  Future<void> _updateAppThemeMode(ThemeMode? newMode) async {
+    if (newMode != null && newMode != _currentAppThemeMode) {
+      await _settingsService.saveAppThemeMode(newMode);
+      if (mounted) {
+        setState(() { _currentAppThemeMode = newMode; });
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('App theme change will apply on next app start.')),
+        );
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -88,7 +102,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 Text("Reader Settings", style: Theme.of(context).textTheme.titleLarge),
                 const Divider(),
                 
-                // Default Reader Theme Setting
                 ListTile(
                   title: const Text('Default Reader Theme'),
                   trailing: DropdownButton<ReaderThemeSetting>(
@@ -103,7 +116,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   ),
                 ),
 
-                // Default Font Size Setting
                 ListTile(
                   title: Text('Default Font Size: ${_currentDefaultFontSize.toStringAsFixed(0)}'),
                 ),
@@ -111,13 +123,30 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   value: _currentDefaultFontSize,
                   min: 10.0,
                   max: 30.0,
-                  divisions: 20, // (30-10) / 1.0
+                  divisions: 20, 
                   label: _currentDefaultFontSize.round().toString(),
-                  onChanged: (double value) {
-                    // setState is called within _updateDefaultFontSize after saving
-                    _updateDefaultFontSize(value);
+                  onChanged: (double value) { 
+                    setState(() { _currentDefaultFontSize = value; }); 
                   },
+                  onChangeEnd: _updateDefaultFontSize, 
                 ),
+
+                ListTile(
+                  title: const Text('Reader Font Family'),
+                  trailing: DropdownButton<String>(
+                    value: _fontFamilyOptions.contains(_currentReaderFontFamily) 
+                           ? _currentReaderFontFamily 
+                           : 'Default', // Fallback if saved value is not in options
+                    items: _fontFamilyOptions.map((String fontFamily) {
+                      return DropdownMenuItem<String>(
+                        value: fontFamily,
+                        child: Text(fontFamily),
+                      );
+                    }).toList(),
+                    onChanged: _updateReaderFontFamily,
+                  ),
+                ),
+
                 const SizedBox(height: kMediumPadding),
                 Text("Application Settings", style: Theme.of(context).textTheme.titleLarge),
                 const Divider(),
@@ -134,8 +163,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     onChanged: _updateAppThemeMode,
                   ),
                 ),
-
-                // Add more settings here later
               ],
             ),
     );

--- a/src/lib/ui/screens/settings_screen.dart
+++ b/src/lib/ui/screens/settings_screen.dart
@@ -1,8 +1,78 @@
 // lib/ui/screens/settings_screen.dart
 import 'package:flutter/material.dart';
+import 'package:novelist/services/settings_service.dart';
+import 'package:novelist/core/app_constants.dart';
 
-class SettingsScreen extends StatelessWidget {
+class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  final SettingsService _settingsService = SettingsService();
+  
+  ReaderThemeSetting _currentReaderTheme = ReaderThemeSetting.system;
+  double _currentDefaultFontSize = 16.0;
+  ThemeMode _currentAppThemeMode = ThemeMode.system; // For overall app theme
+
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSettings();
+  }
+
+  Future<void> _loadSettings() async {
+    setState(() { _isLoading = true; });
+    _currentReaderTheme = await _settingsService.getReaderTheme();
+    _currentDefaultFontSize = await _settingsService.getDefaultFontSize();
+    _currentAppThemeMode = await _settingsService.getAppThemeMode();
+    if (mounted) {
+      setState(() { _isLoading = false; });
+    }
+  }
+
+  Future<void> _updateReaderTheme(ReaderThemeSetting? newTheme) async {
+    if (newTheme != null) {
+      await _settingsService.saveReaderTheme(newTheme);
+      if (mounted) {
+        setState(() {
+          _currentReaderTheme = newTheme;
+        });
+        // Optionally, provide immediate feedback or tell user to restart reader/app for some settings
+      }
+    }
+  }
+
+  Future<void> _updateDefaultFontSize(double newSize) async {
+    await _settingsService.saveDefaultFontSize(newSize);
+    if (mounted) {
+      setState(() {
+        _currentDefaultFontSize = newSize;
+      });
+    }
+  }
+  
+  Future<void> _updateAppThemeMode(ThemeMode? newMode) async {
+    if (newMode != null) {
+      await _settingsService.saveAppThemeMode(newMode);
+      if (mounted) {
+        setState(() {
+          _currentAppThemeMode = newMode;
+        });
+        // This change might require a way to notify MaterialApp to rebuild.
+        // Often done via a ChangeNotifierProvider at the root or by restarting.
+        // For now, saving it is the first step.
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('App theme change will apply on next app start (or with theme controller).')),
+        );
+      }
+    }
+  }
+
 
   @override
   Widget build(BuildContext context) {
@@ -10,12 +80,64 @@ class SettingsScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Settings'),
       ),
-      body: const Center(
-        child: Text(
-          'Application settings will be here.',
-          style: TextStyle(fontSize: 18),
-        ),
-      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(kDefaultPadding),
+              children: <Widget>[
+                Text("Reader Settings", style: Theme.of(context).textTheme.titleLarge),
+                const Divider(),
+                
+                // Default Reader Theme Setting
+                ListTile(
+                  title: const Text('Default Reader Theme'),
+                  trailing: DropdownButton<ReaderThemeSetting>(
+                    value: _currentReaderTheme,
+                    items: ReaderThemeSetting.values.map((ReaderThemeSetting theme) {
+                      return DropdownMenuItem<ReaderThemeSetting>(
+                        value: theme,
+                        child: Text(theme.name[0].toUpperCase() + theme.name.substring(1)),
+                      );
+                    }).toList(),
+                    onChanged: _updateReaderTheme,
+                  ),
+                ),
+
+                // Default Font Size Setting
+                ListTile(
+                  title: Text('Default Font Size: ${_currentDefaultFontSize.toStringAsFixed(0)}'),
+                ),
+                Slider(
+                  value: _currentDefaultFontSize,
+                  min: 10.0,
+                  max: 30.0,
+                  divisions: 20, // (30-10) / 1.0
+                  label: _currentDefaultFontSize.round().toString(),
+                  onChanged: (double value) {
+                    // setState is called within _updateDefaultFontSize after saving
+                    _updateDefaultFontSize(value);
+                  },
+                ),
+                const SizedBox(height: kMediumPadding),
+                Text("Application Settings", style: Theme.of(context).textTheme.titleLarge),
+                const Divider(),
+                ListTile(
+                  title: const Text('App Theme'),
+                  trailing: DropdownButton<ThemeMode>(
+                    value: _currentAppThemeMode,
+                    items: ThemeMode.values.map((ThemeMode mode) {
+                      return DropdownMenuItem<ThemeMode>(
+                        value: mode,
+                        child: Text(mode.name[0].toUpperCase() + mode.name.substring(1)),
+                      );
+                    }).toList(),
+                    onChanged: _updateAppThemeMode,
+                  ),
+                ),
+
+                // Add more settings here later
+              ],
+            ),
     );
   }
 }

--- a/src/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/src/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,11 +8,13 @@ import Foundation
 import file_picker
 import flutter_inappwebview_macos
 import path_provider_foundation
+import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/src/pubspec.lock
+++ b/src/pubspec.lock
@@ -733,6 +733,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "20cbd561f743a342c76c151d6ddb93a9ce6005751e7aa458baad3858bfbfb6ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.10"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   html: ^0.15.6
   flutter_epub_viewer: ^1.2.1
   image: ^3.3.0
+  shared_preferences: ^2.5.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR introduces persistent user settings for both the ePub reader and the overall app theme, enhancing user experience by remembering preferences across sessions. The main changes include:

### Key Changes

- **SettingsService Implementation:**  
  - Added a new `SettingsService` class using `SharedPreferences` to persist user preferences for:
    - Reader theme (light, dark, sepia, system)
    - Reader font size
    - Reader font family
    - App-wide theme mode (light, dark, system)

- **EpubPackageController Enhancements:**  
  - Loads and applies user preferences (font size, theme, font family) on initialization.
  - Persists changes to reader settings using `SettingsService`.
  - Applies theme and font family dynamically to the ePub viewer via controller methods and JavaScript injection.
  - Improved error handling and logging for settings application.

- **App Theme Initialization:**  
  - On app startup, loads the saved app theme mode from `SettingsService` and applies it to `MaterialApp`.
  - `NovelistApp` now accepts an `initialThemeMode` parameter.

- **Code Cleanup:**  
  - Removed outdated comments and improved documentation in affected files.
  - Refactored initialization logic in `main.dart` for clarity and maintainability.